### PR TITLE
Update df.world-site.xml

### DIFF
--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -59,7 +59,7 @@
         <uint32_t name="seed1" comment='random'/>
         <uint32_t name="seed2" comment='random'/>
 
-        <int32_t name="unk_10c"/>
+        <int32_t name="resident_count" comment='count living in houses and shops'/>
         <int32_t name="unk_110"/>
         <int32_t name="unk_114"/>
         <int32_t name="unk_118"/>
@@ -72,7 +72,7 @@
         <int32_t name="unk_134"/>
         <int32_t name="unk_138"/>
 
-        <int32_t comment='v0.34.01'/>
+        <int32_t name="site_level" comment='v0.34.01'/>
 
         <stl-vector name="unk_13c">
             <pointer>


### PR DESCRIPTION
some guesses at site unknowns. Site level is for towns (only?) maybe somebody could think of a better name. Idea is that if level=0 town does not have any shops or a fort, as it increases count of shops grows and later it gets a town wall etc.
